### PR TITLE
Allow dist.ini version = propagating to PM files

### DIFF
--- a/lib/Dist/Zilla/Plugin/RewriteVersion.pm
+++ b/lib/Dist/Zilla/Plugin/RewriteVersion.pm
@@ -34,9 +34,20 @@ my $assign_regex = qr{
     our \s+ \$VERSION \s* = \s* (['"])($version::LAX)\1 \s* ;
 }x;
 
+=attr skip_version_provider
+
+If true, rely on some other mechanism for determining the "current" version
+instead of extracting it from the C<main_module>. Defaults to false.
+
+This enables hard-coding C<version => in C<dist.ini> among other tricks.
+
+=cut
+
+has skip_version_provider => ( is => ro =>, lazy => 1, default => undef );
+
 sub provide_version {
     my ($self) = @_;
-
+    return if $self->skip_version_provider;
     # override (or maybe needed to initialize)
     return $ENV{V} if exists $ENV{V};
 

--- a/t/version_ini.t
+++ b/t/version_ini.t
@@ -1,0 +1,47 @@
+use strict;
+use warnings;
+use Test::More 0.96;
+use utf8;
+
+use Test::DZil;
+use Test::Fatal;
+
+sub _new_tzil {
+    return Builder->from_config(
+        { dist_root => 'corpus/DZT' },
+        {
+            add_files => {
+                'source/dist.ini' => simple_ini(
+                    { version => 3.1415 },
+                    'GatherDir', [ 'RewriteVersion', { skip_version_provider => 1 } ]
+                ),
+            },
+        },
+    );
+}
+
+# Just to make sure nothing leaks through when doing
+# V=0.01 dzil test
+delete $ENV{TRIAL};
+delete $ENV{V};
+
+sub _regex_for_version {
+    my ( $q, $version, $trailing ) = @_;
+    my $exp = $trailing
+      ? qr{^our \$VERSION = $q\Q$version\E$q; \Q$trailing\E}m
+      : qr{^our \$VERSION = $q\Q$version\E$q;}m;
+    return $exp;
+}
+my $tzil = _new_tzil;
+$tzil->chrome->logger->set_debug(1);
+$tzil->build;
+
+pass("dzil build");
+
+like(
+    $tzil->slurp_file('build/lib/DZT/Sample.pm'),
+    _regex_for_version( q['], '3.1415', '' ),
+    "version from dist.ini used",
+);
+
+done_testing;


### PR DESCRIPTION
This test demonstrates that it is presently not possible to do set `version =` in dist.ini and have it spread to the `.pm` files.

This is basically the downside by running in multiple phases, and by being a version provider in addition to a version munger  :anguished:

This approach is useful if:
- You want to set version from dist.ini instead of the mainmodule.pm
- You want mainmodule.pm to have a usable `$VERSION` in it ( ruling out PkgVersion and OurPkgVersion )
- You want `dzil build` to emit a built dist with `mainmodule.pm` having the version in `dist.ini` ( Not possible with PkgVersion, just warns/dies , OurPkgVersion blindly replaces a magic comment and produces invalid code )
- You _WANT_ to be setting `version =` in dist.ini manually ( @ambs )

This would already be possible with `RewriteVersion` if not for RewriteVersions being a `-VersionProvider`, because that of course trips up here: 

https://metacpan.org/source/RJBS/Dist-Zilla-5.020/lib/Dist/Zilla.pm#L107

``` perl
 my $version = $self->_version_override;
  for my $plugin ($self->plugins_with(-VersionProvider)->flatten) {
    next unless defined(my $this_version = $plugin->provide_version);

    $self->log_fatal('attempted to set version twice') if defined $version;  ## BANG
```

And so yes, your comments an aeon ago with regards to "Plugins should only have one phase" and "Plugins should be named after their phase" I agree more and more with every day. :smile: 
