### PR TITLE
use a less confusing log message when munging the file

### DIFF
--- a/lib/Dist/Zilla/Plugin/BumpVersionAfterRelease.pm
+++ b/lib/Dist/Zilla/Plugin/BumpVersionAfterRelease.pm
@@ -255,6 +255,7 @@ Here are some other plugins for managing C<$VERSION> in your distribution:
 * L<Dist::Zilla::Plugin::OverridePkgVersion>
 * L<Dist::Zilla::Plugin::SurgicalPkgVersion>
 * L<Dist::Zilla::Plugin::PkgVersionIfModuleWithPod>
+* L<Dist::Zilla::Plugin::RewriteVersion::Transitional>
 
 =cut
 

--- a/lib/Dist/Zilla/Plugin/BumpVersionAfterRelease.pm
+++ b/lib/Dist/Zilla/Plugin/BumpVersionAfterRelease.pm
@@ -102,7 +102,7 @@ sub rewrite_version {
     my $iolayer = sprintf( ":raw:encoding(%s)", $file->encoding );
 
     # read source file
-    my $content = Path::Tiny::path( $file->name )->slurp( { binmode => $iolayer } );
+    my $content = Path::Tiny::path( $file->_original_name )->slurp( { binmode => $iolayer } );
 
     my $comment = $self->zilla->is_trial ? ' # TRIAL' : '';
     my $code = "our \$VERSION = '$version';$comment";

--- a/lib/Dist/Zilla/Plugin/RewriteVersion.pm
+++ b/lib/Dist/Zilla/Plugin/RewriteVersion.pm
@@ -81,7 +81,7 @@ sub munge_file {
       unless version::is_lax($version);
 
     if ( $self->rewrite_version( $file, $version ) ) {
-        $self->log_debug( [ 'adding $VERSION assignment to %s', $file->name ] );
+        $self->log_debug( [ 'updating $VERSION assignment in %s', $file->name ] );
     }
     else {
         $self->log( [ q[Skipping: no "our $VERSION = '...'" found in "%s"], $file->name ] );

--- a/lib/Dist/Zilla/Plugin/RewriteVersion.pm
+++ b/lib/Dist/Zilla/Plugin/RewriteVersion.pm
@@ -56,6 +56,7 @@ sub provide_version {
 
     my ( $quote, $version ) = $content =~ m{^$assign_regex[^\n]*$}ms;
 
+    $self->log_debug([ 'extracted version from main module: %s', $version ]) if $version;
     return $version;
 }
 

--- a/lib/Dist/Zilla/Plugin/RewriteVersion.pm
+++ b/lib/Dist/Zilla/Plugin/RewriteVersion.pm
@@ -154,6 +154,11 @@ For most modules, this should work just fine.
 See L<BumpVersionAfterRelease|Dist::Zilla::Plugin::BumpVersionAfterRelease> for
 more details and usage examples.
 
+=head1 SEE ALSO
+
+=for :list
+* L<Dist::Zilla::Plugin::RewriteVersion::Transitional>
+
 =cut
 
 # vim: ts=4 sts=4 sw=4 et:

--- a/t/basic.t
+++ b/t/basic.t
@@ -119,8 +119,8 @@ for my $c (@cases) {
         like( $dquote_bld, qr/1;\s+# last line/, "last line correct in double-quoted file" );
 
         ok(
-            grep( { /adding \$VERSION assignment/ } @{ $tzil->log_messages } ),
-            "we log adding a version",
+            grep( { /updating \$VERSION assignment/ } @{ $tzil->log_messages } ),
+            "we log updating a version",
         ) or diag join( "\n", @{ $tzil->log_messages } );
 
         my $makefilePL = $tzil->slurp_file('build/Makefile.PL');

--- a/t/in-memory.t
+++ b/t/in-memory.t
@@ -1,0 +1,69 @@
+use strict;
+use warnings;
+use Test::More 0.96;
+
+use Test::DZil;
+use Test::Fatal;
+use Path::Tiny;
+
+sub _new_tzil {
+    {
+        package inc::MyGatherer;
+        use Moose;
+        with 'Dist::Zilla::Role::FileGatherer';
+        use Dist::Zilla::File::InMemory;
+        sub gather_files
+        {
+            shift->add_file(Dist::Zilla::File::InMemory->new(
+                name => Path::Tiny::path(qw(lib Bar.pm))->stringify,
+                content => 'in memory',
+            ));
+        }
+    }
+    return Builder->from_config(
+        { dist_root => 'corpus/DZT' },
+        {
+            add_files => {
+                'source/dist.ini' => simple_ini(
+                    { version => 3.1415 },
+                    'GatherDir',
+                    '=inc::MyGatherer',
+                    [ 'RewriteVersion', { skip_version_provider => 1 } ],
+                    'FakeRelease',
+                    'BumpVersionAfterRelease',
+                ),
+                path(qw(source lib Foo.pm)) => "package Foo;\n\nour \$VERSION = '0.002';\n\n1;\n",
+            },
+        },
+    );
+}
+
+# Just to make sure nothing leaks through when doing
+# V=0.01 dzil test
+delete $ENV{TRIAL};
+delete $ENV{V};
+
+my $tzil = _new_tzil;
+$tzil->chrome->logger->set_debug(1);
+is(
+    exception { $tzil->release },
+    undef,
+    'build and release proceeds normally',
+);
+
+is(
+    path($tzil->tempdir, qw(source lib Foo.pm))->slurp_utf8,
+    "package Foo;\n\nour \$VERSION = '3.1416';\n\n1;\n",
+    '.pm contents in source saw the version updated',
+);
+
+ok(
+    grep { $_ eq '[BumpVersionAfterRelease] Skipping: "lib/Bar.pm" not found in source' }
+        @{ $tzil->log_messages },
+    'got appropriate log messages about skipping in-memory file',
+);
+
+diag 'got log messages: ', explain $tzil->log_messages
+    if not Test::Builder->new->is_passing;
+
+done_testing;


### PR DESCRIPTION
"adding $VERSION assignment to lib/Foo.pm" implies a new declaration is being
added, rather than simply modifying the value of the one already there.
(Plus it disambiguates with [RewriteVersion::Transitional], which really
*does* add a new declaration.)