### PR TITLE
do not add # TRIAL to in-repo files after release

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,10 @@ Revision history for Dist-Zilla-Plugin-BumpVersionAfterRelease
 
 {{$NEXT}}
 
+    [CHANGED]
+
+    - removed addition of # TRIAL suffix to the repository files after release
+
 0.009     2015-01-27 06:47:35-05:00 America/New_York
 
     [CHANGED]

--- a/lib/Dist/Zilla/Plugin/BumpVersionAfterRelease.pm
+++ b/lib/Dist/Zilla/Plugin/BumpVersionAfterRelease.pm
@@ -104,8 +104,7 @@ sub rewrite_version {
     # read source file
     my $content = Path::Tiny::path( $file->_original_name )->slurp( { binmode => $iolayer } );
 
-    my $comment = $self->zilla->is_trial ? ' # TRIAL' : '';
-    my $code = "our \$VERSION = '$version';$comment";
+    my $code = "our \$VERSION = '$version';";
 
     if (
         $self->global

--- a/t/basic.t
+++ b/t/basic.t
@@ -139,7 +139,7 @@ for my $c (@cases) {
         );
 
         my $orig = $tzil->slurp_file('source/lib/DZT/Sample.pm');
-        my $next_re = _regex_for_version( q['], next_version($version) );
+        my $next_re = _regex_for_version( q['], next_version($version), $c->{trial} ? "# TRIAL" : "" );
 
         like( $orig, $next_re, "version line updated in single-quoted source file" );
 
@@ -155,7 +155,7 @@ for my $c (@cases) {
 
         like(
             $orig,
-            _regex_for_version( q['], next_version($version) ),
+            $next_re,
             "version line updated from double-quotes to single-quotes in source file",
         );
 

--- a/t/basic.t
+++ b/t/basic.t
@@ -139,7 +139,8 @@ for my $c (@cases) {
         );
 
         my $orig = $tzil->slurp_file('source/lib/DZT/Sample.pm');
-        my $next_re = _regex_for_version( q['], next_version($version), $c->{trial} ? "# TRIAL" : "" );
+        my $next_re = _regex_for_version( q['], next_version($version) );
+        $next_re = qr/$next_re$/m;
 
         like( $orig, $next_re, "version line updated in single-quoted source file" );
 

--- a/t/in-memory.t
+++ b/t/in-memory.t
@@ -42,6 +42,7 @@ sub _new_tzil {
 # V=0.01 dzil test
 delete $ENV{TRIAL};
 delete $ENV{V};
+delete $ENV{RELEASE_STATUS};
 
 my $tzil = _new_tzil;
 $tzil->chrome->logger->set_debug(1);

--- a/t/version_ini.t
+++ b/t/version_ini.t
@@ -24,6 +24,7 @@ sub _new_tzil {
 # V=0.01 dzil test
 delete $ENV{TRIAL};
 delete $ENV{V};
+delete $ENV{RELEASE_STATUS};
 
 sub _regex_for_version {
     my ( $q, $version, $trailing ) = @_;


### PR DESCRIPTION
Since trial status can only be known at release time, and a previous release's
trial status has no bearing on the status of the next release, it makes no
sense to add this comment to the in-repo version of the files.