### PR TITLE
add or retain an eval $VERSION when version has an underscore

### DIFF
--- a/Changes
+++ b/Changes
@@ -5,6 +5,7 @@ Revision history for Dist-Zilla-Plugin-BumpVersionAfterRelease
     [CHANGED]
 
     - removed addition of # TRIAL suffix to the repository files after release
+    - add "$VERSION = eval $VERSION" when version contains an underscore
 
 0.009     2015-01-27 06:47:35-05:00 America/New_York
 

--- a/lib/Dist/Zilla/Plugin/BumpVersionAfterRelease.pm
+++ b/lib/Dist/Zilla/Plugin/BumpVersionAfterRelease.pm
@@ -106,7 +106,8 @@ sub rewrite_version {
     my $content = Path::Tiny::path( $file->_original_name )->slurp( { binmode => $iolayer } );
 
     my $code = "our \$VERSION = '$version';";
-    $code .= "\n\$VERSION = eval \$VERSION;" if $version =~ /_/ and scalar($version =~ /\./g) <= 1;
+    (my $clean_version = $version) =~ tr/_//;
+    $code .= "\n\$VERSION = '$clean_version';" if $version ne $clean_version;
 
     if (
         $self->global

--- a/lib/Dist/Zilla/Plugin/BumpVersionAfterRelease.pm
+++ b/lib/Dist/Zilla/Plugin/BumpVersionAfterRelease.pm
@@ -90,7 +90,8 @@ sub munge_file {
 }
 
 my $assign_regex = qr{
-    our \s+ \$VERSION \s* = \s* (['"])$version::LAX\1 \s* ;
+    our \s+ \$VERSION \s* = \s* (['"])$version::LAX\1 \s* ; (?:\s* \# \s TRIAL)? \N*
+    (?:\n \$VERSION \s = \s eval \s \$VERSION;)?
 }x;
 
 sub rewrite_version {
@@ -105,6 +106,7 @@ sub rewrite_version {
     my $content = Path::Tiny::path( $file->_original_name )->slurp( { binmode => $iolayer } );
 
     my $code = "our \$VERSION = '$version';";
+    $code .= "\n\$VERSION = eval \$VERSION;" if $version =~ /_/ and scalar($version =~ /\./g) <= 1;
 
     if (
         $self->global

--- a/lib/Dist/Zilla/Plugin/RewriteVersion.pm
+++ b/lib/Dist/Zilla/Plugin/RewriteVersion.pm
@@ -98,7 +98,8 @@ sub rewrite_version {
 
     my $code = "our \$VERSION = '$version';";
     $code .= " # TRIAL" if $self->zilla->is_trial;
-    $code .= "\n\$VERSION = eval \$VERSION;" if $version =~ /_/ and scalar($version =~ /\./g) <= 1;
+    (my $clean_version = $version) =~ tr/_//;
+    $code .= "\n\$VERSION = '$clean_version';" if $version ne $clean_version;
 
     if (
         $self->global

--- a/lib/Dist/Zilla/Plugin/RewriteVersion.pm
+++ b/lib/Dist/Zilla/Plugin/RewriteVersion.pm
@@ -31,7 +31,8 @@ has global => (
 );
 
 my $assign_regex = qr{
-    our \s+ \$VERSION \s* = \s* (['"])($version::LAX)\1 \s* ;
+    our \s+ \$VERSION \s* = \s* (['"])($version::LAX)\1 \s* ; (?:\s* \# \s TRIAL)? \N*
+    (?:\n \$VERSION \s = \s eval \s \$VERSION;)?
 }x;
 
 =attr skip_version_provider
@@ -95,8 +96,9 @@ sub rewrite_version {
 
     my $content = $file->content;
 
-    my $comment = $self->zilla->is_trial ? ' # TRIAL' : '';
-    my $code = "our \$VERSION = '$version';$comment";
+    my $code = "our \$VERSION = '$version';";
+    $code .= " # TRIAL" if $self->zilla->is_trial;
+    $code .= "\n\$VERSION = eval \$VERSION;" if $version =~ /_/ and scalar($version =~ /\./g) <= 1;
 
     if (
         $self->global

--- a/t/underscore_version.t
+++ b/t/underscore_version.t
@@ -1,0 +1,92 @@
+use strict;
+use warnings;
+
+use Test::More;
+use if $ENV{AUTHOR_TESTING}, 'Test::Warnings';
+use Test::DZil;
+use Test::Fatal;
+use Path::Tiny;
+
+delete $ENV{RELEASE_STATUS};
+delete $ENV{TRIAL};
+delete $ENV{V};
+
+
+my $tzil = Builder->from_config(
+    { dist_root => 'does-not-exist' },
+    {
+        add_files => {
+            path(qw(source dist.ini)) => dist_ini(
+                { # configs as in simple_ini, but no version assignment
+                    name     => 'DZT-Sample',
+                    abstract => 'Sample DZ Dist',
+                    author   => 'E. Xavier Ample <example@example.org>',
+                    license  => 'Perl_5',
+                    copyright_holder => 'E. Xavier Ample',
+                },
+                [ GatherDir => ],
+                [ MetaConfig => ],
+                [ RewriteVersion => ],
+                [ FakeRelease => ],
+                [ BumpVersionAfterRelease => ],
+            ),
+            path(qw(source lib Foo.pm)) => "package Foo;\n\nour \$VERSION = '0.004_002';\n\n1;\n",
+            path(qw(source lib Foo Bar.pm)) => "package Foo::Bar;\n\nour \$VERSION = '0.004_002';\n\$VERSION = eval \$VERSION;\n\n1;\n",
+            path(qw(source lib Foo Baz.pm)) => "package Foo::Baz;\n\nour \$VERSION = '0.004_002'; # TRIAL\n\$VERSION = eval \$VERSION;\n\n1;\n",
+        },
+    },
+);
+
+$tzil->chrome->logger->set_debug(1);
+is(
+    exception { $tzil->release },
+    undef,
+    'build and release proceeds normally',
+);
+
+is(
+    $tzil->version,
+    '0.004_002',
+    'version was properly extracted from .pm file',
+);
+
+is(
+    path($tzil->tempdir, qw(build lib Foo.pm))->slurp_utf8,
+    "package Foo;\n\nour \$VERSION = '0.004_002'; # TRIAL\n\$VERSION = eval \$VERSION;\n\n1;\n",
+    'TRIAL comment and eval line are added',
+);
+
+is(
+    path($tzil->tempdir, qw(build lib Foo Bar.pm))->slurp_utf8,
+    "package Foo::Bar;\n\nour \$VERSION = '0.004_002'; # TRIAL\n\$VERSION = eval \$VERSION;\n\n1;\n",
+    'TRIAL comment is added; eval line is retained',
+);
+
+is(
+    path($tzil->tempdir, qw(build lib Foo Baz.pm))->slurp_utf8,
+    "package Foo::Baz;\n\nour \$VERSION = '0.004_002'; # TRIAL\n\$VERSION = eval \$VERSION;\n\n1;\n",
+    'TRIAL comment and eval line are retained',
+);
+
+is(
+    path($tzil->tempdir, qw(source lib Foo.pm))->slurp_utf8,
+    "package Foo;\n\nour \$VERSION = '0.004_003';\n\$VERSION = eval \$VERSION;\n\n1;\n",
+    '.pm contents in source saw the underscore version incremented, and eval added',
+);
+
+is(
+    path($tzil->tempdir, qw(source lib Foo Bar.pm))->slurp_utf8,
+    "package Foo::Bar;\n\nour \$VERSION = '0.004_003';\n\$VERSION = eval \$VERSION;\n\n1;\n",
+    '.pm contents in source saw the underscore version incremented and eval retained',
+);
+
+is(
+    path($tzil->tempdir, qw(source lib Foo Baz.pm))->slurp_utf8,
+    "package Foo::Baz;\n\nour \$VERSION = '0.004_003';\n\$VERSION = eval \$VERSION;\n\n1;\n",
+    '.pm contents in source saw the underscore version incremented, TRIAL comment removed and eval retained',
+);
+
+diag 'got log messages: ', explain $tzil->log_messages
+    if not Test::Builder->new->is_passing;
+
+done_testing;

--- a/t/underscore_version.t
+++ b/t/underscore_version.t
@@ -31,8 +31,8 @@ my $tzil = Builder->from_config(
                 [ BumpVersionAfterRelease => ],
             ),
             path(qw(source lib Foo.pm)) => "package Foo;\n\nour \$VERSION = '0.004_002';\n\n1;\n",
-            path(qw(source lib Foo Bar.pm)) => "package Foo::Bar;\n\nour \$VERSION = '0.004_002';\n\$VERSION = eval \$VERSION;\n\n1;\n",
-            path(qw(source lib Foo Baz.pm)) => "package Foo::Baz;\n\nour \$VERSION = '0.004_002'; # TRIAL\n\$VERSION = eval \$VERSION;\n\n1;\n",
+            path(qw(source lib Foo Bar.pm)) => "package Foo::Bar;\n\nour \$VERSION = '0.004_002';\n\$VERSION = '0.004002';\n\n1;\n",
+            path(qw(source lib Foo Baz.pm)) => "package Foo::Baz;\n\nour \$VERSION = '0.004_002'; # TRIAL\n\$VERSION = '0.004002';\n\n1;\n",
         },
     },
 );
@@ -52,38 +52,38 @@ is(
 
 is(
     path($tzil->tempdir, qw(build lib Foo.pm))->slurp_utf8,
-    "package Foo;\n\nour \$VERSION = '0.004_002'; # TRIAL\n\$VERSION = eval \$VERSION;\n\n1;\n",
-    'TRIAL comment and eval line are added',
+    "package Foo;\n\nour \$VERSION = '0.004_002'; # TRIAL\n\$VERSION = '0.004002';\n\n1;\n",
+    'TRIAL comment and second assignment are added',
 );
 
 is(
     path($tzil->tempdir, qw(build lib Foo Bar.pm))->slurp_utf8,
-    "package Foo::Bar;\n\nour \$VERSION = '0.004_002'; # TRIAL\n\$VERSION = eval \$VERSION;\n\n1;\n",
-    'TRIAL comment is added; eval line is retained',
+    "package Foo::Bar;\n\nour \$VERSION = '0.004_002'; # TRIAL\n\$VERSION = '0.004002';\n\n1;\n",
+    'TRIAL comment is added; second assignment is retained',
 );
 
 is(
     path($tzil->tempdir, qw(build lib Foo Baz.pm))->slurp_utf8,
-    "package Foo::Baz;\n\nour \$VERSION = '0.004_002'; # TRIAL\n\$VERSION = eval \$VERSION;\n\n1;\n",
-    'TRIAL comment and eval line are retained',
+    "package Foo::Baz;\n\nour \$VERSION = '0.004_002'; # TRIAL\n\$VERSION = '0.004002';\n\n1;\n",
+    'TRIAL comment and second assignment are retained',
 );
 
 is(
     path($tzil->tempdir, qw(source lib Foo.pm))->slurp_utf8,
-    "package Foo;\n\nour \$VERSION = '0.004_003';\n\$VERSION = eval \$VERSION;\n\n1;\n",
-    '.pm contents in source saw the underscore version incremented, and eval added',
+    "package Foo;\n\nour \$VERSION = '0.004_003';\n\$VERSION = '0.004003';\n\n1;\n",
+    '.pm contents in source saw the underscore version incremented, and second assignment added',
 );
 
 is(
     path($tzil->tempdir, qw(source lib Foo Bar.pm))->slurp_utf8,
-    "package Foo::Bar;\n\nour \$VERSION = '0.004_003';\n\$VERSION = eval \$VERSION;\n\n1;\n",
-    '.pm contents in source saw the underscore version incremented and eval retained',
+    "package Foo::Bar;\n\nour \$VERSION = '0.004_003';\n\$VERSION = '0.004003';\n\n1;\n",
+    '.pm contents in source saw the underscore version incremented and second assignment retained',
 );
 
 is(
     path($tzil->tempdir, qw(source lib Foo Baz.pm))->slurp_utf8,
-    "package Foo::Baz;\n\nour \$VERSION = '0.004_003';\n\$VERSION = eval \$VERSION;\n\n1;\n",
-    '.pm contents in source saw the underscore version incremented, TRIAL comment removed and eval retained',
+    "package Foo::Baz;\n\nour \$VERSION = '0.004_003';\n\$VERSION = '0.004003';\n\n1;\n",
+    '.pm contents in source saw the underscore version incremented, TRIAL comment removed and second assignment retained',
 );
 
 diag 'got log messages: ', explain $tzil->log_messages

--- a/t/underscore_version_override.t
+++ b/t/underscore_version_override.t
@@ -1,0 +1,95 @@
+use strict;
+use warnings;
+
+use Test::More;
+use if $ENV{AUTHOR_TESTING}, 'Test::Warnings';
+use Test::DZil;
+use Test::Fatal;
+use Path::Tiny;
+
+delete $ENV{RELEASE_STATUS};
+delete $ENV{TRIAL};
+delete $ENV{V};
+
+# we are done with 0.004_* trial releases - time to go stable!
+$ENV{V} = '0.005';
+
+my $tzil = Builder->from_config(
+    { dist_root => 'does-not-exist' },
+    {
+        add_files => {
+            path(qw(source dist.ini)) => dist_ini(
+                { # configs as in simple_ini, but no version assignment
+                    name     => 'DZT-Sample',
+                    abstract => 'Sample DZ Dist',
+                    author   => 'E. Xavier Ample <example@example.org>',
+                    license  => 'Perl_5',
+                    copyright_holder => 'E. Xavier Ample',
+                },
+                [ GatherDir => ],
+                [ MetaConfig => ],
+                [ RewriteVersion => ],
+                [ FakeRelease => ],
+                [ BumpVersionAfterRelease => ],
+            ),
+            # test files with the eval and without
+            path(qw(source lib Foo.pm)) => "package Foo;\n\nour \$VERSION = '0.004_003'; # TRIAL\n\n1;\n",
+            path(qw(source lib Foo Bar.pm)) => "package Foo::Bar;\n\nour \$VERSION = '0.004_003';\n\$VERSION = eval \$VERSION;\n\n1;\n",
+            path(qw(source lib Foo Baz.pm)) => "package Foo::Baz;\n\nour \$VERSION = '0.004_003'; # TRIAL\n\$VERSION = eval \$VERSION;\n\n1;\n",
+        },
+    },
+);
+
+$tzil->chrome->logger->set_debug(1);
+is(
+    exception { $tzil->release },
+    undef,
+    'build and release proceeds normally',
+);
+
+is(
+    $tzil->version,
+    '0.005',
+    'version was taken from the environment',
+);
+
+is(
+    path($tzil->tempdir, qw(build lib Foo.pm))->slurp_utf8,
+    "package Foo;\n\nour \$VERSION = '0.005';\n\n1;\n",
+    'TRIAL comment is removed and version reset',
+);
+
+is(
+    path($tzil->tempdir, qw(build lib Foo Bar.pm))->slurp_utf8,
+    "package Foo::Bar;\n\nour \$VERSION = '0.005';\n\n1;\n",
+    'eval line is removed and version reset',
+);
+
+is(
+    path($tzil->tempdir, qw(build lib Foo Baz.pm))->slurp_utf8,
+    "package Foo::Baz;\n\nour \$VERSION = '0.005';\n\n1;\n",
+    'TRIAL comment and eval line are removed and version reset',
+);
+
+is(
+    path($tzil->tempdir, qw(source lib Foo.pm))->slurp_utf8,
+    "package Foo;\n\nour \$VERSION = '0.006';\n\n1;\n",
+    '.pm contents in source saw the version incremented and TRIAL removed',
+);
+
+is(
+    path($tzil->tempdir, qw(source lib Foo Bar.pm))->slurp_utf8,
+    "package Foo::Bar;\n\nour \$VERSION = '0.006';\n\n1;\n",
+    '.pm contents in source saw the version incremented and eval removed',
+);
+
+is(
+    path($tzil->tempdir, qw(source lib Foo Baz.pm))->slurp_utf8,
+    "package Foo::Baz;\n\nour \$VERSION = '0.006';\n\n1;\n",
+    '.pm contents in source saw the version incremented and TRIAL and eval removed',
+);
+
+diag 'got log messages: ', explain $tzil->log_messages
+    if not Test::Builder->new->is_passing;
+
+done_testing;


### PR DESCRIPTION
Adds `$VERSION = eval $VERSION;` when using an underscore trial version; it turns out that Dist::Zilla is quite happy to deal with underscore versions everywhere; we just usually don't :)

(I'm doing a similar patch for PkgVersion; will link when it's up.)

This includes the commits for PR #10 to resolve conflicts. Please take that one first; it is much more important.