### PR TITLE
Workaround for backslahes under Windows

### DIFF
--- a/t/basic.t
+++ b/t/basic.t
@@ -220,7 +220,7 @@ for my $c (@cases) {
         ) or diag 'got distmeta: ', explain $tzil->distmeta;
 
         cmp_deeply(
-            $tzil->log_messages,
+            [ map { my $txt = $_; $txt =~ s/\\/\//g if $txt =~ /^\[BumpVersionAfterRelease\]/; $txt } @{$tzil->log_messages} ],
             superbagof(
                 '[RewriteVersion] updating $VERSION assignment in lib/DZT/Sample.pm',
                 '[BumpVersionAfterRelease] bumped $VERSION in ' . path($tzil->tempdir, qw(source lib DZT Sample.pm)),


### PR DESCRIPTION
I found, what I think, is a problem in test t/basic.t under Win32. Please consider kindly my patch.

It appears that the function $tzil->log_messages under win32 produces
some (but not all) backslashes instead of forwardslashes in filenames.

This causes multiple test failures (the backslashes are in $data as a SuperBag,
therefore they do not appear in the test output):

t/basic.t ........................
    *   Failed test 'got appropriate log messages about updating both $VERSION
    *     statements, in both locations'
    *   at t/basic.t line 222.
    * Comparing $data as a SuperBag
    * Missing: '[BumpVersionAfterRelease] bumped $VERSION in C:/...
    *   /Dist-Zilla-Plugin-BumpVersionAfterRelease-0.012/tmp
    *   /eZ_xXO07eD/source/lib/DZT/Sample.pm'
    * Looks like you failed 1 test of 19.

This patch is a workaround to replace backslashes by forwardslashes
if a message starts with /^\[BumpVersionAfterRelease\]/.