### PR TITLE
"all_matching" option - only bump versions that matched release version

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,11 @@ Revision history for Dist-Zilla-Plugin-BumpVersionAfterRelease
 
 {{$NEXT}}
 
+    [ADDED]
+
+    - New "all_matching" option for [BumpVersionAfterRelease], which only
+      bumps $VERSIONs that match the release version
+
 0.015     2016-04-03 13:43:32-04:00 America/New_York
 
     [ADDED]

--- a/corpus/DZT/lib/DZT/Mismatched.pm
+++ b/corpus/DZT/lib/DZT/Mismatched.pm
@@ -1,0 +1,8 @@
+package DZT::Mismatched;
+# ABSTRACT: a sample module with mismatched $VERSIONs
+our $VERSION = '0.003'; # first VERSION
+
+package DZT::Inner;
+our $VERSION = '0.004'; # second VERSION
+
+1;                      # last line

--- a/lib/Dist/Zilla/Plugin/BumpVersionAfterRelease.pm
+++ b/lib/Dist/Zilla/Plugin/BumpVersionAfterRelease.pm
@@ -26,7 +26,7 @@ has allow_decimal_underscore => (
 =attr global
 
 If true, all occurrences of the version pattern will be replaced.  Otherwise,
-only the first occurrence is replaced.  Defaults to false.
+only the first occurrence in each file is replaced.  Defaults to false.
 
 =cut
 

--- a/lib/Dist/Zilla/Plugin/BumpVersionAfterRelease.pm
+++ b/lib/Dist/Zilla/Plugin/BumpVersionAfterRelease.pm
@@ -35,6 +35,18 @@ has global => (
     isa => 'Bool',
 );
 
+=attr all_matching
+
+If true, only versions matching that of the last release will be replaced.
+Defaults to false.
+
+=cut
+
+has all_matching => (
+    is  => 'ro',
+    isa => 'Bool',
+);
+
 =attr munge_makefile_pl
 
 If there is a F<Makefile.PL> in the root of the repository, its version will be
@@ -128,11 +140,12 @@ sub rewrite_version {
       if $version =~ /_/ and scalar( $version =~ /\./g ) <= 1;
 
     my $assign_regex = $self->assign_re();
+    my $matching_regex = $self->matching_re($self->zilla->version);
 
     if (
-        $self->global
-        ? ( $content =~ s{^$assign_regex[^\n]*$}{$code}msg )
-        : ( $content =~ s{^$assign_regex[^\n]*$}{$code}ms )
+            $self->global ? ( $content =~ s{^$assign_regex[^\n]*$}{$code}msg )
+          : $self->all_matching ? ( $content =~ s{^$matching_regex[^\n]*$}{$code}msg  )
+          : ( $content =~ s{^$assign_regex[^\n]*$}{$code}ms )
       )
     {
         # append+truncate to preserve file mode

--- a/lib/Dist/Zilla/Plugin/BumpVersionAfterRelease/_Util.pm
+++ b/lib/Dist/Zilla/Plugin/BumpVersionAfterRelease/_Util.pm
@@ -58,6 +58,16 @@ sub assign_re {
     }x;
 }
 
+sub matching_re {
+    my ($self, $release_version) = @_;
+    return qr{
+        our \s+ \$VERSION \s* = \s*
+        (['"])(\Q$release_version\E)\1 \s* ;
+        (?:\s* \# \s TRIAL)? [^\n]*
+        (?:\n \$VERSION \s = \s eval \s \$VERSION;)?
+    }x;
+}
+
 sub check_valid_version {
     my ( $self, $version ) = @_;
 


### PR DESCRIPTION
This is useful for distributions like URI, where some packages have $VERSIONs that are out of step with the distribution version (and since they are much higher than the distribution version it is not desirable to alter the dist version to match the maximum of all of them).  In such a distribution, we won't use `[RewriteVersion]` at all, but simply count on the in-repo versions to be correct (while using `[BumpVersionAfterRelease]` to move the synchronized versions forward).