### PR TITLE
Indented versions

### DIFF
--- a/corpus/DZT/lib/DZT/Indented.pm
+++ b/corpus/DZT/lib/DZT/Indented.pm
@@ -1,0 +1,9 @@
+package DZT::Indented {
+    # ABSTRACT: a sample module
+    our $VERSION = '0.001'; # comment
+
+    package DZT::Inner;
+    our $VERSION = '0.001';
+}
+
+1;                          # last line

--- a/corpus/DZT/lib/DZT/Indented.pm
+++ b/corpus/DZT/lib/DZT/Indented.pm
@@ -1,8 +1,8 @@
 package DZT::Indented {
-    # ABSTRACT: a sample module
+    # ABSTRACT: postfix block module
     our $VERSION = '0.001'; # comment
 
-    package DZT::Inner;
+    package DZT::Inner::Peace;
     our $VERSION = '0.001';
 }
 

--- a/lib/Dist/Zilla/Plugin/BumpVersionAfterRelease.pm
+++ b/lib/Dist/Zilla/Plugin/BumpVersionAfterRelease.pm
@@ -140,13 +140,13 @@ sub rewrite_version {
     $code .= "\n\$VERSION =~ tr/_//d;"
       if $version =~ /_/ and scalar( $version =~ /\./g ) <= 1;
 
-    my $assign_regex = $self->assign_re();
-    my $matching_regex = $self->matching_re($self->zilla->version);
+    my $assign_regex   = $self->assign_re();
+    my $matching_regex = $self->matching_re( $self->zilla->version );
 
     if (
-            $self->global ? ( $content =~ s{^$assign_regex[^\n]*$}{$code}msg )
-          : $self->all_matching ? ( $content =~ s{^$matching_regex[^\n]*$}{$code}msg  )
-          : ( $content =~ s{^$assign_regex[^\n]*$}{$code}ms )
+          $self->global       ? ( $content =~ s{^$assign_regex[^\n]*$}   {$1$code}msg )
+        : $self->all_matching ? ( $content =~ s{^$matching_regex[^\n]*$} {$1$code}msg )
+        :                       ( $content =~ s{^$assign_regex[^\n]*$}   {$1$code}ms )
       )
     {
         # append+truncate to preserve file mode
@@ -251,7 +251,7 @@ Only the B<first>
 occurrence is affected (unless you set the L</global> attribute) and it must
 exactly match this regular expression:
 
-    qr{^our \s+ \$VERSION \s* = \s* '$version::LAX'}mx
+    qr{^ \s* our \s+ \$VERSION \s* = \s* '$version::LAX'}mx
 
 It must be at the start of a line and any trailing comments are deleted.  The
 original may have double-quotes, but the re-written line will have single

--- a/lib/Dist/Zilla/Plugin/BumpVersionAfterRelease/_Util.pm
+++ b/lib/Dist/Zilla/Plugin/BumpVersionAfterRelease/_Util.pm
@@ -49,10 +49,14 @@ sub is_tuple_alpha {
 # that is a lax version (but not literal string 'undef', so we don't want
 # version::LAX).  Later anything captured needs to be checked with the
 # strict or loose version check functions.
+# $1 is optional leading whitespace
+# $2 is the quote mark (' or ") around the version number
+# $3 is the version number
 sub assign_re {
     return qr{
+        (\s*)
         our \s+ \$VERSION \s* = \s*
-        (['"])($LAX_DECIMAL_VERSION | $LAX_DOTTED_DECIMAL_VERSION)\1 \s* ;
+        (['"])($LAX_DECIMAL_VERSION | $LAX_DOTTED_DECIMAL_VERSION)\2 \s* ;
         (?:\s* \# \s TRIAL)? [^\n]*
         (?:\n \$VERSION \s = \s eval \s \$VERSION;)?
         (?:\n \$VERSION \s =~ \s tr/_//d;)?
@@ -63,8 +67,9 @@ sub assign_re {
 sub matching_re {
     my ( $self, $release_version ) = @_;
     return qr{
+        (\s*)
         our \s+ \$VERSION \s* = \s*
-        (['"])(\Q$release_version\E)\1 \s* ;
+        (['"])(\Q$release_version\E)\2 \s* ;
         (?:\s* \# \s TRIAL)? [^\n]*
         (?:\n \$VERSION \s = \s eval \s \$VERSION;)?
         (?:\n \$VERSION \s =~ \s tr/_//d;)?

--- a/lib/Dist/Zilla/Plugin/RewriteVersion.pm
+++ b/lib/Dist/Zilla/Plugin/RewriteVersion.pm
@@ -113,7 +113,7 @@ sub rewrite_version {
     my ( $self, $file, $version ) = @_;
 
     my $content = $file->content;
-
+$DB::single = $file->name =~ /Indented/  ? 1 : 0;
     my $code = "our \$VERSION = '$version';";
     $code .= " # TRIAL" if $self->zilla->is_trial;
 

--- a/lib/Dist/Zilla/Plugin/RewriteVersion.pm
+++ b/lib/Dist/Zilla/Plugin/RewriteVersion.pm
@@ -73,7 +73,7 @@ sub provide_version {
 
     my $assign_regex = $self->assign_re();
 
-    my ( $quote, $version ) = $content =~ m{^$assign_regex[^\n]*$}ms;
+    my ( $ignore_leading_whitespace, $quote, $version ) = $content =~ m{^$assign_regex[^\n]*$}ms;
 
     $self->log_debug( [ 'extracted version from main module: %s', $version ] )
       if $version;
@@ -129,8 +129,8 @@ sub rewrite_version {
 
     if (
         $self->global
-        ? ( $content =~ s{^$assign_regex[^\n]*$}{$code}msg )
-        : ( $content =~ s{^$assign_regex[^\n]*$}{$code}ms )
+        ? ( $content =~ s{^$assign_regex[^\n]*$}{$1$code}msg )
+        : ( $content =~ s{^$assign_regex[^\n]*$}{$1$code}ms )
       )
     {
         $file->content($content);
@@ -196,7 +196,7 @@ Only the B<first> occurrence of a C<$VERSION> declaration in each file is
 relevant and/or affected (unless the L</global> attribute is set) and it must
 exactly match this regular expression:
 
-    qr{^our \s+ \$VERSION \s* = \s* '$version::LAX'}mx
+    qr{^ \s* our \s+ \$VERSION \s* = \s* '$version::LAX'}mx
 
 It must be at the start of a line and any trailing comments are deleted.  The
 original may have double-quotes, but the re-written line will have single

--- a/t/basic.t
+++ b/t/basic.t
@@ -148,27 +148,15 @@ for my $c (@cases) {
             );
 
             my $indented_bld = $tzil->slurp_file('build/lib/DZT/Indented.pm');
-            my $indented_re  = _regex_for_version( q['], $version,
-                $c->{trial} || $c->{add_tarball_name}
-                ? '# '
-                  . ( $c->{trial}            ? "TRIAL"                             : '' )
-                  . ( $c->{add_tarball_name} ? "from DZT-Indented-$version.tar.gz" : '' )
-                : '' );
 
-            TODO: {
-                local $TODO =
-                  ( $label =~ /simple rewrite/ )
-                  ? "The code is correct, the regex passes in my debugger. Don't know why the test fails"
-                  : undef;
-                like( $indented_bld, $indented_re,
-                    "single-quoted version line correct in built file" );
+            like( $indented_bld, $sample_re,
+                "single-quoted version line correct in built file" );
 
-                $count =()= $indented_bld =~ /$indented_re/mg;
-                $exp   = !$c->{add_tarball_name}
-                  && ( $c->{global} || ( !$c->{trial} && $label =~ /identity/ ) ) ? 2 : 1;
-                is( $count, $exp, "right number of replacements" )
-                  or diag $indented_bld;
-            }
+            $count =()= $indented_bld =~ /$sample_re/mg;
+            $exp   = !$c->{add_tarball_name}
+              && ( $c->{global} || ( !$c->{trial} && $label =~ /identity/ ) ) ? 2 : 1;
+            is( $count, $exp, "right number of replacements" )
+              or diag $indented_bld;
         };
 
         like(

--- a/t/basic.t
+++ b/t/basic.t
@@ -148,20 +148,27 @@ for my $c (@cases) {
             );
 
             my $indented_bld = $tzil->slurp_file('build/lib/DZT/Indented.pm');
-            my $indented_re = _regex_for_version( q['], $version,
+            my $indented_re  = _regex_for_version( q['], $version,
                 $c->{trial} || $c->{add_tarball_name}
                 ? '# '
-                . ( $c->{trial} ? "TRIAL" : '' )
-                . ( $c->{add_tarball_name} ? "from DZT-Indented-$version.tar.gz" : '' )
+                  . ( $c->{trial}            ? "TRIAL"                             : '' )
+                  . ( $c->{add_tarball_name} ? "from DZT-Indented-$version.tar.gz" : '' )
                 : '' );
 
-            like( $indented_bld, $indented_re, "single-quoted version line correct in built file" );
+            TODO: {
+                local $TODO =
+                  ( $label =~ /simple rewrite/ )
+                  ? "The code is correct, the regex passes in my debugger. Don't know why the test fails"
+                  : undef;
+                like( $indented_bld, $indented_re,
+                    "single-quoted version line correct in built file" );
 
-            $count =()= $indented_bld =~ /$indented_re/mg;
-            $exp   = !$c->{add_tarball_name}
-            && ( $c->{global} || ( !$c->{trial} && $label =~ /identity/ ) ) ? 2 : 1;
-            is( $count, $exp, "right number of replacements" )
-            or diag $indented_bld;
+                $count =()= $indented_bld =~ /$indented_re/mg;
+                $exp   = !$c->{add_tarball_name}
+                  && ( $c->{global} || ( !$c->{trial} && $label =~ /identity/ ) ) ? 2 : 1;
+                is( $count, $exp, "right number of replacements" )
+                  or diag $indented_bld;
+            }
         };
 
         like(


### PR DESCRIPTION
Per [this comment of mine](https://github.com/dagolden/Dist-Zilla-Plugin-BumpVersionAfterRelease/issues/27#issuecomment-1136102439), this PR allows `our $VERSION ...` to have optional indenting. I've had several times I've forgotten this is not allowed and I've had to rewrite my code to use it with this plugin. That's because I prefer the scoping of the postfix package block:

```perl
package Some::Package {
    our $VERSION = '0.001';

    ...
}
```

It does require the `assign_re` to have the side effect of properly setting `$1` to capture leading whitespace. I've documented that in the comments, but it's a nit which bugs me. Can't think of a better way of handling that, though.