### PR TITLE
Assert minimum version of Package::Stash

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -9,7 +9,8 @@ copyright_year   = 2014
 stopwords = VersionFromModule
 
 [Prereqs]
-Dist::Zilla = 5.040
+Dist::Zilla    = 5.040
+Package::Stash = 0.04 ; first version with get_or_add_package_symbol()
 
 [Prereqs / DevelopRequires]
 Test::Portability::Files = 0.07 ; better ANSI file format conformance


### PR DESCRIPTION
In reading [cpan tester failure reports for this module](http://www.cpantesters.org/cpan/report/3b818100-0c4d-11e9-b2fc-4ec6980eb343), we see the following error:

```
Can't locate object method "get_or_add_package_symbol" via package "Package::Stash" at /Users/stan/perl5/lib/perl5/darwin-thread-multi-2level/Class/MOP/Package.pm line 128.
```

According to [the `Package::Stash` changelog](https://metacpan.org/dist/Package-Stash/changes), that method was added in version 0.04 in 2010. This patch lists that as a minimum dependency.

I was going to bump it to 0.40, the current version of `Package::Stash`, but I don't know how conservative you prefer to be with versions.