### PR TITLE
fix string comparisons with $] to use numeric comparison instead

### DIFF
--- a/t/basic.t
+++ b/t/basic.t
@@ -177,7 +177,7 @@ for my $c (@cases) {
         my $next_re = _regex_for_version( q['], next_version($version) );
         $next_re = qr/$next_re$/m;
 
-        local $TODO = 'qr/...$/m is broken before 5.10' if $] lt '5.010000';
+        local $TODO = 'qr/...$/m is broken before 5.10' if "$]" < '5.010000';
         if (!$c->{all_matching} || $version eq '0.001') {
             like( $orig, $next_re, "version line updated in single-quoted source file" );
         }
@@ -200,7 +200,7 @@ for my $c (@cases) {
 
         $orig = $tzil->slurp_file('source/lib/DZT/DQuote.pm');
 
-        local $TODO = 'qr/...$/m is broken before 5.10' if $] lt '5.010000';
+        local $TODO = 'qr/...$/m is broken before 5.10' if "$]" < '5.010000';
         if (!$c->{all_matching} || $version eq '0.001') {
             like( $orig, $next_re, "version line updated from double-quotes to single-quotes in source file");
         }
@@ -213,7 +213,7 @@ for my $c (@cases) {
 
         $orig = $tzil->slurp_file('source/lib/DZT/Mismatched.pm');
 
-        local $TODO = 'qr/...$/m is broken before 5.10' if $] lt '5.010000';
+        local $TODO = 'qr/...$/m is broken before 5.10' if "$]" < '5.010000';
 
         if ($c->{all_matching} && $version ne '0.003' && $version ne '0.004') {
             unlike( $orig, $next_re, "version line not updated in source file - did not match release version");


### PR DESCRIPTION
The fix follows Zefram's suggestion from
https://www.nntp.perl.org/group/perl.perl5.porters/2012/05/msg186846.html

> On older perls, however, $] had a numeric value that was built up using
> floating-point arithmetic, such as 5+0.006+0.000002.  This would not
> necessarily match the conversion of the complete value from string form
> [perl #72210].  You can work around that by explicitly stringifying
> $] (which produces a correct string) and having *that* numify (to a
> correctly-converted floating point value) for comparison.  I cultivate
> the habit of always stringifying $] to work around this, regardless of
> the threshold where the bug was fixed.  So I'd write
>
>     use if "$]" >= 5.014, warnings => "non_unicode";

This ensures that the comparisons will still work when Perl's major version changes to anything greater than 9.